### PR TITLE
fix(angularAMD): Use providerInjector, instead of the runtime $injector....

### DIFF
--- a/src/angularAMD.js
+++ b/src/angularAMD.js
@@ -7,7 +7,8 @@ define(function () {
         alternate_queue = [],
         app_name,
         app_injector,
-        app_cached_providers = {};
+        app_cached_providers = {},
+        config_injector; // store the captured providerInjector (config-time injector)
     
     // Private method to check if angularAMD has been initialized
     function checkAngularAMDInitialized() {
@@ -164,7 +165,12 @@ define(function () {
                     args = q[2];
                 
                 if (app_cached_providers.hasOwnProperty(provider)) {
-                    var cachedProvider = app_cached_providers[provider];
+                    var cachedProvider;
+                    if (provider === "$injector" && method === "invoke") {
+                        cachedProvider = config_injector;
+                    } else {
+                        cachedProvider = app_cached_providers[provider];
+                    }
                     //console.log("'" + item.name + "': applying " + provider + "." + method + " for args: ", args);
                     cachedProvider[method].apply(null, args);
                 } else {
@@ -255,8 +261,9 @@ define(function () {
         
         // Cache provider needed
         app.config(
-            ['$controllerProvider', '$compileProvider', '$filterProvider', '$animateProvider', '$provide', function (controllerProvider, compileProvider, filterProvider, animateProvider, provide) {
+            ['$controllerProvider', '$compileProvider', '$filterProvider', '$animateProvider', '$provide', '$injector', function (controllerProvider, compileProvider, filterProvider, animateProvider, provide, injector) {
                 // Cache Providers
+                config_injector = injector;
                 app_cached_providers = {
                     $controllerProvider: controllerProvider,
                     $compileProvider: compileProvider,


### PR DESCRIPTION
fix(angularAMD): Use providerInjector, instead of the runtime $injector
...  allows Providers to be injected into .config blocks.

Closes #28, #21
