### PR TITLE
removing module.register

### DIFF
--- a/src/angularAMD.js
+++ b/src/angularAMD.js
@@ -278,17 +278,39 @@ define(function () {
                     $provide: provide
                 };
                 
+                angular.extend(app, {
+                  controller : function(name, constructor) {
+                    controllerProvider.register(name, constructor);
+                    return this;
+                  },
+                  directive : function(name, constructor) {
+                    compileProvider.directive(name, constructor);
+                    return this;
+                  },
+                  filter : function(name, constructor) {
+                    filterProvider.register(name, constructor);
+                    return this;
+                  },
+                  factory : function(name, constructor) {
+                    provide.factory(name, constructor);
+                    return this;
+                  },
+                  service : function(name, constructor) {
+                    provide.service(name, constructor);
+                    return this;
+                  },
+                  constant : function(name, constructor) {
+                    provide.constant(name, constructor);
+                    return this;
+                  },
+                  value : function(name, constructor) {
+                    provide.value(name, constructor);
+                    return this;
+                  },
+                  animation: angular.bind(animateProvider, animateProvider.register)
+                });
+                
                 // Create a app.register object
-                app.register = {
-                    controller: controllerProvider.register,
-                    directive: compileProvider.directive,
-                    filter: filterProvider.register,
-                    factory: provide.factory,
-                    service: provide.service,
-                    constant: provide.constant,
-                    value: provide.value,
-                    animation: angular.bind(animateProvider, animateProvider.register)
-                };
             
             }]
         );

--- a/test/unit/lib/controller.js
+++ b/test/unit/lib/controller.js
@@ -4,7 +4,7 @@
 define(['app','ngload!services'], function (app) {
     'use strict';
     var ctrl_name = "MainController";
-    app.register.controller(ctrl_name, ['$scope', 'UtestFactory', 'UtestService', function ($scope, UtestFactory, UtestService) {
+    app.controller(ctrl_name, ['$scope', 'UtestFactory', 'UtestService', function ($scope, UtestFactory, UtestService) {
         $scope.ctrl_name = ctrl_name;
         $scope.utest_factory = UtestFactory;
         $scope.utest_service = UtestService;

--- a/test/unit/lib/regController.js
+++ b/test/unit/lib/regController.js
@@ -4,7 +4,7 @@
 define(['app','regServices'], function (app) {
     'use strict';
     var ctrl_name = "RegController";
-    app.register.controller(ctrl_name, ['$scope', 'UtestRegFactory', 'UtestRegService', function ($scope, UtestRegFactory, UtestRegService) {
+    app.controller(ctrl_name, ['$scope', 'UtestRegFactory', 'UtestRegService', function ($scope, UtestRegFactory, UtestRegService) {
         $scope.ctrl_name = ctrl_name;
         $scope.utest_reg_factory = UtestRegFactory;
         $scope.utest_reg_service = UtestRegService;

--- a/test/unit/lib/regServices.js
+++ b/test/unit/lib/regServices.js
@@ -10,31 +10,30 @@ define(['app', 'angularAMD'], function(app, angularAMD) {
     'use strict';
 
     // Services coded using regular angular approach
-    var services = app.register,
-        inject = angularAMD.inject,
+    var inject = angularAMD.inject,
         utest_reg_result = {};
     
     utest_reg_result.reg_constant_name = "regServices.reg_constant_name QSiNx5JlLP";
-    services.constant("reg_constant_name", utest_reg_result.reg_constant_name);
+    app.constant("reg_constant_name", utest_reg_result.reg_constant_name);
     
     utest_reg_result.factory_name = "UtestRegFactory.name OVw2nHyfO7";
-    services.factory("UtestRegFactory", function (reg_constant_name) {
+    app.factory("UtestRegFactory", function (reg_constant_name) {
         // Make sure that constant_name is setup after this factory.
         return { name: utest_reg_result.factory_name, "const_name": reg_constant_name };
     });
     
     utest_reg_result.reg_value_name = "regServices.reg_value_name PMlzn3kISG";
-    services.value("reg_value_name", utest_reg_result.reg_value_name);
+    app.value("reg_value_name", utest_reg_result.reg_value_name);
     
     utest_reg_result.service_name = "UtestRegService.name xrA1xp5wrF";
-    services.service("UtestRegService", function (reg_value_name) {
+    app.service("UtestRegService", function (reg_value_name) {
         // Make sure that value_name is defined after this service
         this.name = utest_reg_result.service_name;
         this.val_name = reg_value_name;
     });
 
     utest_reg_result.directive_name = "regServices.directive_name 1LSC3LPxLG";
-    services.directive('utestRegDirective', function () {
+    app.directive('utestRegDirective', function () {
         return {
             restrict: 'A',
             link: function (scope, elm, attr) {
@@ -44,14 +43,14 @@ define(['app', 'angularAMD'], function(app, angularAMD) {
     });
 
     utest_reg_result.reg_filter_name = "regServices.reg_filter_name ABOmVXJZQH";
-    services.filter('utestRegFilter', function () {
+    app.filter('utestRegFilter', function () {
         return function (input) {
             return input + " " + utest_reg_result.reg_filter_name;
         };
     });
     
     // Create Animation
-    services.animation('.service-reg-animation', function ($log, $interval) {
+    app.animation('.service-reg-animation', function ($log, $interval) {
         return {
             addClass : function(element, className, done) {
                 if ( className === "custom-hide") {
@@ -69,7 +68,7 @@ define(['app', 'angularAMD'], function(app, angularAMD) {
     });
     
     // Return the result in a factory
-    services.factory('UtestRegServiceResult', function () {
+    app.factory('UtestRegServiceResult', function () {
         return utest_reg_result;
     });
     

--- a/www/js/scripts/controller/home_ctrl.js
+++ b/www/js/scripts/controller/home_ctrl.js
@@ -1,5 +1,5 @@
 define(['app', 'directive/navMenu','prettify'], function (app) {
-    app.register.controller('HomeController', ['$scope', '$window', function ($scope, $window) {
+    app.controller('HomeController', ['$scope', '$window', function ($scope, $window) {
         $scope.title = "angularAMD";
         $scope.openGitHubPage = function () {
             //console.log("trackEvent: ViewGitHub");

--- a/www/js/scripts/controller/map_ctrl.js
+++ b/www/js/scripts/controller/map_ctrl.js
@@ -1,5 +1,5 @@
 define(['app', 'service/mapServices', 'directive/navMenu'], function (app) {
-    app.register.controller('MapController', ['$scope', 'MapService', function ($scope, MapService) {
+    app.controller('MapController', ['$scope', 'MapService',function ($scope, MapService) {
         $scope.title = "Where is Colosseo?";
         $scope.latitude = 41.8902;
         $scope.longitude = 12.4923;

--- a/www/js/scripts/controller/modules_ctrl.js
+++ b/www/js/scripts/controller/modules_ctrl.js
@@ -1,5 +1,5 @@
 define(['app', 'ngload!service/dataServices', 'directive/write', 'directive/navMenu'], function (app) {
-    app.register.controller('ModulesController', ['$scope', '$log', 'DeferredObject', 'DeferredString', '$rootScope', function ($scope, $log, DeferredObject, DeferredString, $rootScope) {
+    app.controller('ModulesController', ['$scope', '$log', 'DeferredObject', 'DeferredString', '$rootScope', function ($scope, $log, DeferredObject, DeferredString, $rootScope) {
         DeferredObject.get("This is defered response", 2000).then(function (result) {
             $scope.obj_response = result;
         });

--- a/www/js/scripts/controller/pictures_ctrl.js
+++ b/www/js/scripts/controller/pictures_ctrl.js
@@ -1,6 +1,6 @@
 define(['app', 'service/picturesService', 'ngload!ui-bootstrap', 'directive/navMenu'], function (app) {
         
-    app.register.controller('PicturesController', ['$scope','Pictures', function ($scope, Pictures) {
+    app.controller('PicturesController', ['$scope', 'Pictures', function ($scope, Pictures) {
         $scope.slideChangeInterval = 4000;
         
         $scope.$watch('cityModel', function (newValue) {

--- a/www/js/scripts/directive/navMenu.js
+++ b/www/js/scripts/directive/navMenu.js
@@ -1,7 +1,7 @@
 /*jslint node: true */
 /*global define */
 define(['app'], function (app) {
-    app.register.controller("navMenuController", ['$scope', '$route', 'SiteName', '$window', '$location', function ($scope, $route, SiteName, $window, $location) {
+    app.controller("navMenuController", ['$scope', '$route', 'SiteName', '$window', '$location', function ($scope, $route, SiteName, $window, $location) {
         var tab_name = $route.current.navTab,
             ga_path = SiteName + $location.path();
         
@@ -16,7 +16,7 @@ define(['app'], function (app) {
         
     }]);
     
-    app.register.directive('navMenu', function () {
+    app.directive('navMenu', function () {
         return {
             restrict: 'A',
             controller: 'navMenuController',

--- a/www/js/scripts/directive/write.js
+++ b/www/js/scripts/directive/write.js
@@ -1,6 +1,6 @@
 // customDirectives
 define(['app'], function (app) {
-    app.register.directive('ngWrite', ['$timeout', '$log', function ($timeout, $log) {
+    app.directive('ngWrite', ['$timeout', '$log', function ($timeout, $log) {
         return {
             restrict: 'A',
             //require: "^ngController",

--- a/www/js/scripts/service/mapServices.js
+++ b/www/js/scripts/service/mapServices.js
@@ -1,6 +1,6 @@
 // convert Google Maps into an AMD module
 define(['app', 'async!//maps.google.com/maps/api/js?v=3&sensor=false'], function (app) {
-    app.register.service('MapService', function () {
+    app.service('MapService', function () {
         var gmaps =  window.google.maps,
             mapOptions = {
                 zoom: 15,

--- a/www/js/scripts/service/picturesService.js
+++ b/www/js/scripts/service/picturesService.js
@@ -1,8 +1,6 @@
 // dataServices
-// define(['app','angular-resource'], function (app) {
 define(['app'], function (app) {
-    // app.register.factory('Pictures', ['$http', '$q', '$log', '$resource', function ($http, $q, $log, $resource) {
-    app.register.factory('Pictures', ['$http', '$q', '$log', function ($http, $q, $log) {
+    app.factory('Pictures', ['$http', '$q', '$log', function ($http, $q, $log) {
         var feed_url = "http://ycpi.api.flickr.com/services/feeds/photos_public.gne?format=json&jsoncallback=JSON_CALLBACK&tags=";
         return {
             query: function (tag_name) {
@@ -29,6 +27,7 @@ define(['app'], function (app) {
 /*
 Another way to code this:
 -------------------------
+// define(['app','angular-resource'], function (app) {
 angular.module("dataServices", ['ngResource'])
 .factory('Pictures', ['$http', '$q', '$log', '$resource', function ($http, $q, $log, $resource) {
     var feed_url = "http://ycpi.api.flickr.com/services/feeds/photos_public.gne?format=json&tags=London&jsoncallback=JSON_CALLBACK";


### PR DESCRIPTION
No need separating registering lazy loaded controllers/services/...

Lazy loaded code should be the same as sync or async loaded.
Controllers, services, filters,... should run without angularAMD.

Based on: https://github.com/matjaz/ng-1.x-async-hack
