### PR TITLE
removed  small typo in requireJS paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $routeProvider.when(
 You can avoid passing of `controllerUrl` if you define it in your `main.js` as:
 
 ```Javascript
-paths: { 'HomeController': 'scripts/controller.js' }
+paths: { 'HomeController': 'scripts/controller' }
 ```
 
 The primary purpose of `angularAMD.route` is set `.resolve` property to load controller using `require` statement.


### PR DESCRIPTION
Require js doesn't like .js suffix when you declare a file path in paths
