### PR TITLE
Add support for controller functions with prototypes.

### DIFF
--- a/src/angularAMD.js
+++ b/src/angularAMD.js
@@ -142,6 +142,12 @@ define(function () {
                             if (__AAMDCtrl.prototype) {
                                 this.__proto__ = __AAMDCtrl.prototype;
                             }
+                            if (Array.isArray(__AAMDCtrl) && __AAMDCtrl.length) {
+                                var fn = __AAMDCtrl[__AAMDCtrl.length - 1];
+                                if (fn.prototype) {
+                                    this.__proto__ = fn.prototype;
+                                }
+                            }
                             $injector.invoke(__AAMDCtrl, this, { '$scope': $scope });
                         }
                     }

--- a/src/angularAMD.js
+++ b/src/angularAMD.js
@@ -139,7 +139,9 @@ define(function () {
                     '$scope', '__AAMDCtrl', '$injector',
                     function ($scope, __AAMDCtrl, $injector) {
                         if (typeof __AAMDCtrl !== 'undefined' ) {
-                            this.__proto__ = __AAMDCtrl.prototype;
+                            if (__AAMDCtrl.prototype) {
+                                this.__proto__ = __AAMDCtrl.prototype;
+                            }
                             $injector.invoke(__AAMDCtrl, this, { '$scope': $scope });
                         }
                     }

--- a/src/angularAMD.js
+++ b/src/angularAMD.js
@@ -139,6 +139,7 @@ define(function () {
                     '$scope', '__AAMDCtrl', '$injector',
                     function ($scope, __AAMDCtrl, $injector) {
                         if (typeof __AAMDCtrl !== 'undefined' ) {
+                            this.__proto__ = __AAMDCtrl.prototype;
                             $injector.invoke(__AAMDCtrl, this, { '$scope': $scope });
                         }
                     }


### PR DESCRIPTION
This change adds support for controller functions that have functions
defined in their prototype. This works correctly in angular by default because
the `__proto__` property is set correctly when angular loads the controller.

When the controller is loaded by requirejs the `__proto__` property is set to
the prototype of the intermediate controller function not the function loaded by requirejs.

The use case for this is controllers defined as Typescript classes.