### PR TITLE
added support for angular 1.5 component

### DIFF
--- a/src/angularAMD.js
+++ b/src/angularAMD.js
@@ -408,6 +408,10 @@ define(function () {
                         compileProvider.directive(name, constructor);
                         return this;
                     },
+                    component : function(name, options) {
+                        compileProvider.component(name, options);
+                        return this;
+                    },
                     filter : function(name, constructor) {
                         filterProvider.register(name, constructor);
                         return this;
@@ -498,6 +502,8 @@ define(function () {
     AngularAMD.prototype.controller = executeProvider('controller');
     // .directive
     AngularAMD.prototype.directive = executeProvider('directive');
+    // .component
+    AngularAMD.prototype.component = executeProvider('component');
     // .filter
     AngularAMD.prototype.filter = executeProvider('filter');
     // .factory


### PR DESCRIPTION
Hi, I'd like to add support for Angular 1.5 components.

I've tried creating a simple component with it (just passed an object in and display the value) and it worked. I used Dojo as my AMD loader, though I expect it should also work with Requirejs.

Angular 1.5 components pass a JS object (option) instead of a function (constructor) as the second parameter, but since everything is just being passed directly to Angular I don't see this being an issue.

BTW I would like to mention that the way angularAMD was written, it made it easy to add support for an additional Angular feature. Thanks for making the code easy to modify, and thank you for making angularAMD.