### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Installation
     bower install angularAMD
 
 ### cdn
-    //cdn.jsdelivr.net/angular.amd/0.2/angularAMD.min.js
+    //cdn.jsdelivr.net/gh/marcoslin/angularAMD@0.2.1/dist/angularAMD.min.js
 
 
 Usage


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/gh/marcoslin/angularAMD.

Feel free to ping me if you have any questions regarding this change.